### PR TITLE
s390x compiler optimization bug

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,6 +28,14 @@ else
   FONT_DIRS=--with-add-fonts="${PREFIX}"/fonts
 fi
 
+# This corrects a bug which appeared on s390x with compiler optimizations
+# turned on. The string literal "fontconfig" appears twice in the file
+# src/fcxml.c. It seems that the compiler optimizes to use the same space in
+# memory for both, because the occurrence in FcStarDoctypeDecl is corrupted,
+# leading the strcmp in that function to raise a false positive. The line below
+# prevents this optimization from happening.
+export CFLAGS="${CFLAGS} -fno-merge-constants"
+
 ./configure --prefix="${PREFIX}"                \
             --enable-libxml2                    \
             --enable-static                     \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://www.freedesktop.org/software/fontconfig/release/fontconfig-{{ version }}.tar.bz2
+  url: https://www.freedesktop.org/software/fontconfig/release/fontconfig-{{ version }}.tar.bz2
   sha256: f655dd2a986d7aa97e052261b36aa67b0a64989496361eca8d604e6414006741
   patches:
     # This patch won't be submitted upstream. It's use here is to ensure the prefix used
@@ -71,15 +71,18 @@ test:
     - fc-list
 
 about:
-  home: http://www.freedesktop.org/wiki/Software/fontconfig/
+  home: https://www.freedesktop.org/wiki/Software/fontconfig/
   license: MIT
   license_file: COPYING
+  license_family: MIT
+  license_url: https://opensource.org/licenses/MIT
   summary: 'A library for configuring and customizing font access.'
   description: |
     Fontconfig is a library designed to provide system-wide font configuration,
     customization and application access.
   doc_url: https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
-  dev_url: https://cgit.freedesktop.org/fontconfig/
+  doc_source_url: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/tree/main/doc
+  dev_url: https://gitlab.freedesktop.org/fontconfig/fontconfig
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,10 +41,6 @@ requirements:
   host:
     - freetype
     - libxml2
-    # Commenting out to avoid overdepending errors on macOS; `./configure`
-    # fails to correctly pick up libiconv, even with explicitly invoked with
-    # `--enable-iconv` and `--with-libiconv-prefix`.
-    - libiconv                    # [not linux and not win]
     - libuuid                     # [linux]
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,29 +47,6 @@ requirements:
     - libiconv                    # [not linux and not win]
     - libuuid                     # [linux]
 
-test:
-  requires:
-    - font-ttf-dejavu-sans-mono
-  commands:
-    # Test CLI.
-    - fc-cache --help
-    - fc-cat --help
-    - fc-list --help
-    - fc-match --help
-    - fc-pattern --help
-    - fc-query --help
-    - fc-scan --help
-    - fc-validate --help
-
-    # Test for libraries.
-    - test -f "${PREFIX}/lib/libfontconfig.a"
-    - test -f "${PREFIX}/lib/libfontconfig.dylib"  # [osx]
-    - test -f "${PREFIX}/lib/libfontconfig.so"     # [linux]
-
-    # Test for correct parsing of font .conf files.
-    # This should list a Dejavu-sans font
-    - fc-list
-
 about:
   home: https://www.freedesktop.org/wiki/Software/fontconfig/
   license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - 0001-Disable-test-bz106632.patch    # [win or osx]
     - osx_arm64.patch  # [osx and arm64]
 build:
-  number: 0
+  number: 1
   skip: True                      # [win]
   binary_has_prefix_files:        # [unix]
     - lib/libfontconfig.so.1.*    # [linux]
@@ -48,6 +48,8 @@ requirements:
     - libuuid                     # [linux]
 
 test:
+  requires:
+    - font-ttf-dejavu-sans-mono
   commands:
     # Test CLI.
     - fc-cache --help
@@ -63,6 +65,10 @@ test:
     - test -f "${PREFIX}/lib/libfontconfig.a"
     - test -f "${PREFIX}/lib/libfontconfig.dylib"  # [osx]
     - test -f "${PREFIX}/lib/libfontconfig.so"     # [linux]
+
+    # Test for correct parsing of font .conf files.
+    # This should list a Dejavu-sans font
+    - fc-list
 
 about:
   home: http://www.freedesktop.org/wiki/Software/fontconfig/

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -13,7 +13,7 @@ fc-validate --help
 # Test for libraries.
 echo "Testing for presence of libfontconfig.a in build output"
 test -f "${PREFIX}/lib/libfontconfig.a"
-if [[ ${target_platform} == osx-* ]]; then # osx-*?
+if [[ ${target_platform} == osx-* ]]; then
     echo "Testing for presence of libfontconfig.dylib in build output"
     test -f "${PREFIX}/lib/libfontconfig.dylib"
 else

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -12,7 +12,6 @@ fc-validate --help
 
 # Test for libraries.
 echo "Testing for presence of libfontconfig.a in build output"
-echo ${target_platform}
 test -f "${PREFIX}/lib/libfontconfig.a"
 if [[ ${target_platform} == osx-* ]]; then # osx-*?
     echo "Testing for presence of libfontconfig.dylib in build output"
@@ -23,6 +22,6 @@ else
 fi
 
 # Test for correct parsing of font .conf files.
-# This should not give anything to sterr (for example, "invalid doctype "fontconfig"", see PR #6.
+# This should not give any errors to sterr (for example, "invalid doctype "fontconfig"", see PR #6.
 echo "Testing for correct parsing of font .conf files"
-fc-list 2> /dev/stdout 1> /dev/null | (if grep .; then exit -1; fi)
+fc-list 2> /dev/stdout 1> /dev/null | (if grep "Fontconfig error"; then exit -1; fi)

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -ex
+
+# Test CLI.
+fc-cache --help
+fc-cat --help
+fc-list --help
+fc-match --help
+fc-pattern --help
+fc-query --help
+fc-scan --help
+fc-validate --help
+
+# Test for libraries.
+echo "Testing for presence of libfontconfig.a in build output"
+echo ${target_platform}
+test -f "${PREFIX}/lib/libfontconfig.a"
+if [[ ${target_platform} == osx-* ]]; then # osx-*?
+    echo "Testing for presence of libfontconfig.dylib in build output"
+    test -f "${PREFIX}/lib/libfontconfig.dylib"
+else
+    echo "Testing for presence of libfontconfig.so in build output"
+    test -f "${PREFIX}/lib/libfontconfig.so"
+fi
+
+# Test for correct parsing of font .conf files.
+# This should not give anything to sterr (for example, "invalid doctype "fontconfig"", see PR #6.
+echo "Testing for correct parsing of font .conf files"
+fc-list 2> /dev/stdout 1> /dev/null | (if grep .; then exit -1; fi)


### PR DESCRIPTION
This corrects a bug which appeared on s390x with compiler optimizations turned on. When parsing font configuration files, fontconfig would fail to load the file, stating that the xml file had an `invalid doctype: "fontconfig"`. In fact, this is the correct doctype.

In the source code, the doctype string was being compared against the string literal "fontconfig", in src/fcxml.c. This literal is used twice in that file. It seems that the compiler optimizes to use the same space in memory for both. However, the other literal is being stored in a non-const array and it seems that the array is being overwritten somewhere, leading the strcmp in FcStartDoctypeDecl to raise a false positive.

This PR prevents that type of optimization from happening using a `-fno-merge-constants` compiler flag.

Fontconfig is a dependency of quite a few other packages including qt, so this PR doesn't increase the version number.

***Testing***

A test has been added which covers this bug: `fc-list` is invoked, and stderr is tested for a "Fontconfig error" string. If the string is present, the tests fail.

The fix is added in the last commit, and the failing test before the fix can be seen in the prefect output of the [second to last commit](https://github.com/AnacondaRecipes/fontconfig-feedstock/pull/6/commits/d580c3a7656493aeadab6cc09a2efc19d8d889df).

[Jira issue](https://anaconda.atlassian.net/browse/PKG-338?atlOrigin=eyJpIjoiYzg0ZmY4ZjQ2ZDE5NGE2MWI3YTNhNTIzMDU2NmZlNGEiLCJwIjoiaiJ9)
[Upstream repo](https://gitlab.freedesktop.org/fontconfig/fontconfig)