### PR TITLE
update to support windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+# the conda-build parameters to use for disabling --skip-existing
+build_parameters:
+  - "--suppress-variables"
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,27 @@
+setlocal EnableDelayedExpansion
+@echo on
+
+set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
+
+set ^"MESON_OPTIONS=^
+  --prefix="%LIBRARY_PREFIX%" ^
+  --default-library=shared ^
+  --wrap-mode=nofallback ^
+  --buildtype=release ^
+  --backend=ninja ^
+ ^"
+
+meson setup builddir !MESON_OPTIONS!
+if errorlevel 1 exit 1
+
+meson configure builddir
+if errorlevel 1 exit 1
+
+ninja -v -C builddir -j %CPU_COUNT%
+if errorlevel 1 exit 1
+
+ninja -v -C builddir test -j %CPU_COUNT%
+if errorlevel 1 exit 1
+
+ninja -C builddir install -j %CPU_COUNT%
+if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,8 @@ requirements:
     - freetype
     - libxml2
     - coreutils  # [osx]
-    - unzip      # Required for MT-safe global config test
+    # Required for MT-safe global config test
+    - unzip      # [not win]
     - expat
     - libiconv   # [win]
     - libuuid    # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,7 @@ source:
     - fcf.patch       # [linux]
 
 build:
-  number: 0
-  skip: True                      # [win]
+  number: 1
   binary_has_prefix_files:        # [unix]
     - lib/libfontconfig.so.1.*    # [linux]
     - lib/libfontconfig.*.dylib*  # [osx]
@@ -26,19 +25,27 @@ requirements:
     - {{ compiler('c') }}
     - make
     - pkg-config
-    - gperf
+    - gperf  # [not win]
+    - m2-gperf  # [win]
     - expat
     - gettext 
     - libtool
     - automake
     - autoconf
     - patch
+    - python  # [win]
+    - meson   # [win]
+    - ninja   # [win]
 
   host:
     - freetype
     - libxml2
     - coreutils  # [osx]
     - unzip      # Required for MT-safe global config test
+    - expat
+    - libiconv   # [win]
+    - libuuid    # [linux]
+    - zlib
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,9 @@ package:
 source:
   url: https://www.freedesktop.org/software/fontconfig/release/fontconfig-{{ version }}.tar.gz
   sha256: ae480e9ca34382790312ff062c625ec70df94d6d9a9366e2b2b3d525f7f90387
-  patches:
-    - fcf.patch       # [linux]
+  patches:                  # [linux or win]
+    - fcf.patch             # [linux]
+    - windows-compat.patch  # [win]
 
 build:
   number: 1
@@ -23,16 +24,17 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - make
+    - make   # [not win]
     - pkg-config
     - gperf  # [not win]
     - m2-gperf  # [win]
     - expat
-    - gettext 
-    - libtool
-    - automake
-    - autoconf
-    - patch
+    - gettext   # [not win]
+    - libtool   # [not win]
+    - automake  # [not win]
+    - autoconf  # [not win]
+    - patch     # [not win]
+    - m2-patch  # [win]
     - python  # [win]
     - meson   # [win]
     - ninja   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -64,13 +64,13 @@ about:
     Fontconfig is a library designed to provide system-wide font configuration,
     customization and application access.
   doc_url: https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
-  doc_source_url: https://gitlab.freedesktop.org/fontconfig/fontconfig/-/tree/main/doc
   dev_url: https://gitlab.freedesktop.org/fontconfig/fontconfig
 
 extra:
   recipe-maintainers:
     - ccordoba12
     - jakirkham
+    - katietz
     - mingwandroid
     - ocefpaf
     - pkgw

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -15,5 +15,6 @@ echo "Testing for presence of libfontconfig in build output"
 if not exist %PREFIX%/Library/lib/fontconfig.lib exit /b 1 
 if not exist %PREFIX%/Library/bin/fontconfig-1.dll exit /b 1
 
-dir %PREFIX%/Library/lib
-if not exist %PREFIX%/Library/lib/pkgconfig/fontconfig.pc exit /b 1
+dir %PREFIX%\Library
+dir %PREFIX%\Library\lib
+if not exist %PREFIX%/Library/pkgconfig/fontconfig.pc exit /b 1

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,12 +1,5 @@
 
-fc-cache --help
-fc-cat --help
 fc-list --help
-fc-match --help
-fc-pattern --help
-fc-query --help
-fc-scan --help
-fc-validate --help
 
 REM Test for libraries.
 echo "Testing for presence of libfontconfig in build output"

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -13,5 +13,5 @@ echo "Testing for presence of libfontconfig in build output"
 if not exist %PREFIX%/Library\lib\fontconfig.lib exit /b 1 
 if not exist %PREFIX%\Library\bin\fontconfig-1.dll exit /b 1
 
-dir %PREFIX%\Library\lib\pkgconfig
+rem check for pkgconfig file ...
 if not exist %PREFIX%\Library\lib\pkgconfig\fontconfig.pc exit /b 1

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -9,12 +9,9 @@ fc-scan --help
 fc-validate --help
 
 REM Test for libraries.
-echo "Testing for presence of libfontconfig.a in build output"
-test -f "${PREFIX}/lib/libfontconfig.a"
 echo "Testing for presence of libfontconfig in build output"
-if not exist %PREFIX%/Library/lib/fontconfig.lib exit /b 1 
-if not exist %PREFIX%/Library/bin/fontconfig-1.dll exit /b 1
+if not exist %PREFIX%/Library\lib\fontconfig.lib exit /b 1 
+if not exist %PREFIX%\Library\bin\fontconfig-1.dll exit /b 1
 
-dir %PREFIX%\Library
-dir %PREFIX%\Library\lib
-if not exist %PREFIX%/Library/pkgconfig/fontconfig.pc exit /b 1
+dir %PREFIX%\Library\lib\pkgconfig
+if not exist %PREFIX%\Library\lib\pkgconfig\fontconfig.pc exit /b 1

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -15,3 +15,6 @@ if not exist %PREFIX%\Library\bin\fontconfig-1.dll exit /b 1
 
 rem check for pkgconfig file ...
 if not exist %PREFIX%\Library\lib\pkgconfig\fontconfig.pc exit /b 1
+
+exit /b 0
+

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -1,0 +1,19 @@
+
+fc-cache --help
+fc-cat --help
+fc-list --help
+fc-match --help
+fc-pattern --help
+fc-query --help
+fc-scan --help
+fc-validate --help
+
+REM Test for libraries.
+echo "Testing for presence of libfontconfig.a in build output"
+test -f "${PREFIX}/lib/libfontconfig.a"
+echo "Testing for presence of libfontconfig in build output"
+if not exist %PREFIX%/Library/lib/fontconfig.lib exit /b 1 
+if not exist %PREFIX%/Library/bin/fontconfig-1.dll exit /b 1
+
+dir %PREFIX%/Library/lib
+if not exist %PREFIX%/Library/lib/pkgconfig/fontconfig.pc exit /b 1

--- a/recipe/windows-compat.patch
+++ b/recipe/windows-compat.patch
@@ -1,0 +1,93 @@
+- Our `gperf` requires Unix newlines even on Windows
+- Windows Conda packages don't seem to handle symlinks correctly, so we have to copy
+- conda-forge needs different logic for location fonts.conf in the non-DLL case
+
+diff --git a/src/cutout.py b/src/cutout.py
+index 323eec8..55a3905 100644
+--- a/src/cutout.py
++++ b/src/cutout.py
+@@ -28,7 +28,7 @@ if __name__== '__main__':
+ 
+     stdout = ret.stdout.decode('utf8')
+ 
+-    with open(args[0].output, 'w') as out:
++    with open(args[0].output, 'w', newline='\n') as out:
+         write = True
+         for l in stdout.split('\n'):
+             l = l.strip('\r')
+diff --git a/conf.d/link_confs.py b/conf.d/link_confs.py
+index 11e759a..e6e8ae5 100644
+--- a/conf.d/link_confs.py
++++ b/conf.d/link_confs.py
+@@ -5,6 +5,7 @@ import sys
+ import argparse
+ import platform
+ from pathlib import PurePath
++import shutil
+ 
+ if __name__=='__main__':
+     parser = argparse.ArgumentParser()
+@@ -33,13 +34,5 @@ if __name__=='__main__':
+             os.remove(dst)
+         except FileNotFoundError:
+             pass
+-        try:
+-            os.symlink(src, dst)
+-        except NotImplementedError:
+-            # Not supported on this version of Windows
+-            break
+-        except OSError as e:
+-            # Symlink privileges are not available
+-            if platform.system().lower() == 'windows' and e.winerror == 1314:
+-                break
+-            raise
++
++        shutil.copyfile(src, dst)
+diff --git a/src/fccfg.c b/src/fccfg.c
+index 8d1ad85..a802a03 100644
+--- a/src/fccfg.c
++++ b/src/fccfg.c
+@@ -2455,9 +2455,27 @@ FcConfigGetPath (void)
+ 		char *p;
+ 		if(!GetModuleFileName(NULL, (LPCH) fontconfig_path, sizeof(fontconfig_path)))
+ 			goto bail1;
+-		p = strrchr ((const char *) fontconfig_path, '\\');
+-		if (p) *p = '\0';
+-		strcat ((char *) fontconfig_path, "\\fonts");
++
++		/* fontconfig_path should be initialized by the DllMain above for programs
++		 * that link to fontconfig dynamically, but this code will kick in for
++		 * statically linked users. Here we customize the logic to mirror DllMain -
++		 * we assume we're in $PREFIX/bin and that config is in $PREFIX/etc/fonts.
++		 * This is certainly fallible depending on where the binary lives, but Conda
++		 * doesn't actually rewrite the build prefix in Windows binaries, so we
++		 * can't use that to get a good absolute path. */
++		p = (FcChar8 *) strrchr ((const char *) fontconfig_path, '\\');
++		if (p)
++		{
++			*p = '\0';
++			p = (FcChar8 *) strrchr ((const char *) fontconfig_path, '\\');
++			if (p && (FcStrCmpIgnoreCase (p + 1, (const FcChar8 *) "bin") == 0 ||
++			          FcStrCmpIgnoreCase (p + 1, (const FcChar8 *) "lib") == 0))
++				*p = '\0';
++			strcat ((char *) fontconfig_instprefix, (char *) fontconfig_path);
++			strcat ((char *) fontconfig_path, "\\etc\\fonts");
++		} else {
++			strcat ((char *) fontconfig_path, "\\fonts");
++		}
+ 	}
+ #endif
+     dir = (FcChar8 *) FONTCONFIG_PATH;
+diff --git a/meson.build b/meson.build
+index 6453d8c..69861f7 100644
+--- a/meson.build
++++ b/meson.build
+@@ -334,7 +334,7 @@ else
+   @1@
+   '''
+   gperf_snippet_format = 'echo foo,bar | @0@ -L ANSI-C'
+-  gperf_snippet = run_command(sh, '-c', gperf_snippet_format.format(gperf.full_path()),
++  gperf_snippet = run_command(sh, '-c', gperf_snippet_format.format(fs.as_posix(gperf.full_path())),
+     check: true)
+   gperf_test = gperf_test_format.format('size_t', gperf_snippet.stdout())
+ 


### PR DESCRIPTION
* raised build number
* add bld.bat with ninja/cmake build variant for windows
* incoperate windows compatiblity patch from CF
* adjust runtime dependencies for Windows
* added abs.yaml to get rid of the meaningless over-depending/linking failures
* added run_test.bat file to test for libraries, DLL, and .pc file on Windows (just list-command is really required and supported on Windows)